### PR TITLE
Remove npm install directions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/test/**/build/
 
 ### IntelliJ IDEA ###
+.idea/
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml

--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ It should give you output like the following:
 
 ## Instructions
 
-Walk the student through any setup required to run the lesson (i.e.
-`npm install` and `npm start`).
-
 Use what you've learned in the previous units to:
 
 1. Make sure the case that outputs "0 year(s)" doesn't run anymore - hint: it


### PR DESCRIPTION
Will look into github workflows afterwards to consider that route for hiding solutions

This change is being made in the consumer canvas per the conversation on 7/22 to keep the same modules for Blackrock and AWS to streamline.